### PR TITLE
License Change: LGPLv3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ and a [Quickstart](http://computationalradiationphysics.github.io/pyDive/start.h
 
 ## Software License
 
-pyDive is licensed under the **GPLv3+ and LGPLv3+** (it is *dual licensed*).
-Licences can be found in [GPL](COPYING) or [LGPL](COPYING.LESSER), respectively.
+pyDive is licensed under the **LGPLv3+**.
+Licences can be found in [COPYING](COPYING) and [COPYING.LESSER](COPYING.LESSER), respectively.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ pyDive
 
 Distributed Interactive Visualization and Exploration of large datasets.
 
+[![pypi version](https://img.shields.io/pypi/v/pyDive.svg)](https://pypi.python.org/pypi/pyDive)
+[![Number of pyDive Downloads](https://img.shields.io/pypi/dm/pyDive.svg)](https://pypi.python.org/pypi/pyDive/)
+[![pyDive license](https://img.shields.io/pypi/l/pyDive.svg)](#software-license)
+
 ## What is pyDive?
 
 Use pyDive to work with homogeneous, n-dimensional arrays that are too big to fit into your local machine's memory.

--- a/pyDive/__init__.py
+++ b/pyDive/__init__.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/algorithm.py
+++ b/pyDive/algorithm.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/__init__.py
+++ b/pyDive/arrays/__init__.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/ad_ndarray.py
+++ b/pyDive/arrays/ad_ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/gpu_ndarray.py
+++ b/pyDive/arrays/gpu_ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/h5_ndarray.py
+++ b/pyDive/arrays/h5_ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/local/__init__.py
+++ b/pyDive/arrays/local/__init__.py
@@ -1,22 +1,20 @@
 # -*- coding: utf-8 -*-
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None

--- a/pyDive/arrays/local/ad_ndarray.py
+++ b/pyDive/arrays/local/ad_ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/local/gpu_ndarray.py
+++ b/pyDive/arrays/local/gpu_ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/local/h5_ndarray.py
+++ b/pyDive/arrays/local/h5_ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/arrays/ndarray.py
+++ b/pyDive/arrays/ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/cloned_ndarray/__init__.py
+++ b/pyDive/cloned_ndarray/__init__.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/cloned_ndarray/cloned_ndarray.py
+++ b/pyDive/cloned_ndarray/cloned_ndarray.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/cloned_ndarray/factories.py
+++ b/pyDive/cloned_ndarray/factories.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 __doc__=\

--- a/pyDive/distribution/decomposition.py
+++ b/pyDive/distribution/decomposition.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import numpy as np

--- a/pyDive/distribution/generic_array.py
+++ b/pyDive/distribution/generic_array.py
@@ -1,23 +1,21 @@
 # -*- coding: utf-8 -*-
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/distribution/generic_array_funcs.py
+++ b/pyDive/distribution/generic_array_funcs.py
@@ -5,19 +5,17 @@ Copyright 2015-2016 Heiko Burau
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/distribution/helper.py
+++ b/pyDive/distribution/helper.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/distribution/interengine.py
+++ b/pyDive/distribution/interengine.py
@@ -1,22 +1,20 @@
 """
-Copyright 2015 Heiko Burau
+Copyright 2015-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 import numpy as np

--- a/pyDive/fragment.py
+++ b/pyDive/fragment.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/ipyParallelClient.py
+++ b/pyDive/ipyParallelClient.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None
 

--- a/pyDive/mappings.py
+++ b/pyDive/mappings.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 __doc__=\

--- a/pyDive/picongpu.py
+++ b/pyDive/picongpu.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 __doc__=\

--- a/pyDive/pyDive.py
+++ b/pyDive/pyDive.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 __doc__=\

--- a/pyDive/structured.py
+++ b/pyDive/structured.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 __doc__ =\

--- a/pyDive/test/__init__.py
+++ b/pyDive/test/__init__.py
@@ -1,21 +1,19 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 __doc__ = None

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     name='pyDive',
     version=pyDive.__version__,
     url='http://github.com/ComputationalRadiationPhysics/pyDive',
-    license='GNU Affero General Public License v3',
+    license='GNU Library or Lesser General Public License (LGPL) v3+',
     author='Heiko Burau',
     tests_require=['pytest'],
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,20 @@
 """
-Copyright 2014 Heiko Burau
+Copyright 2014-2016 Heiko Burau
 
 This file is part of pyDive.
 
 pyDive is free software: you can redistribute it and/or modify
-it under the terms of of either the GNU General Public License or
-the GNU Lesser General Public License as published by
+it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 pyDive is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License and the GNU Lesser General Public License
-for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-and the GNU Lesser General Public License along with pyDive.
-If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with pyDive.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 


### PR DESCRIPTION
### Fix

The library was currently licensed **GPLv3+ & LGPLv3+** (dual license) but announced `AGPL` (Affero GPL) to `pypi`. This fixes it in `setup.py`.
### License Change

Since the LGPL has a [permission to fallback to GPL](https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License#Compatibility) build in, there is no need to dual license with GPL. Merge this PR if you agree to the licence change to be only **LGPLv3+** from now on.
### Headers

Updated with a "generic tool user" to not spoil your statistics.
### Misc

Adds some nice shields to the `README.md`.
